### PR TITLE
Resolve several data_roots for svg images when liip_imagine filter is used

### DIFF
--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -26,3 +26,10 @@ services:
             $publicDirectory: '%env(resolve:MONSIEURBIZ_SYLIUS_MEDIA_MANAGER_PUBLIC_FOLDER)%'
             $mediaDirectory: '%env(resolve:MONSIEURBIZ_SYLIUS_MEDIA_MANAGER_ROOT_FOLDER_FROM_PUBLIC)%'
             $maxFileSize: '%env(resolve:MONSIEURBIZ_SYLIUS_MEDIA_MANAGER_MAX_FILE_SIZE)%'
+
+    # Decorator to allow us to have multiple data roots for svg images.
+    MonsieurBiz\SyliusMediaManagerPlugin\Twig\Extension\FilterExtensionDecorator:
+        decorates: 'liip_imagine.templating.filter_extension'
+        arguments:
+            $loaders: '%liip_imagine.loaders%'
+            $publicDir: '%sylius_core.public_dir%'

--- a/src/Resources/views/Admin/MediaManager/Modal/Content/Files/_previewFile.html.twig
+++ b/src/Resources/views/Admin/MediaManager/Modal/Content/Files/_previewFile.html.twig
@@ -5,7 +5,7 @@
     </a>
 {% elseif file.isImage and file.mimeType == 'image/svg+xml' %}
     <a href="/media/{{ filePath }}" target="_blank" rel="noopener noreferrer">
-        <img src="/media/{{ filePath }}" alt="{{ filePath|escape('html_attr') }}" style="max-width: 300px;max-height: 30px;" />
+        <img src="/media/{{ filePath }}" alt="{{ filePath|escape('html_attr') }}" style="max-width: 300px;max-height: 30px; width: 100%; height: 100%" />
     </a>
 {% elseif file.isFile %}
     <a href="/media/{{ filePath }}" target="_blank" rel="noopener noreferrer" class="ui button mini icon">

--- a/src/Twig/Extension/FilterExtensionDecorator.php
+++ b/src/Twig/Extension/FilterExtensionDecorator.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of Monsieur Biz' Media Manager plugin for Sylius.
+ *
+ * (c) Monsieur Biz <sylius@monsieurbiz.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace MonsieurBiz\SyliusMediaManagerPlugin\Twig\Extension;
+
+use Liip\ImagineBundle\Imagine\Cache\CacheManager;
+use Liip\ImagineBundle\Templating\FilterExtension as BaseFilterExtension;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+class FilterExtensionDecorator extends BaseFilterExtension
+{
+    private array $loaders;
+
+    private string $publicDir;
+
+    public function __construct(
+        CacheManager $cache,
+        array $loaders,
+        string $publicDir
+    ) {
+        parent::__construct($cache);
+        $this->loaders = $loaders;
+        $this->publicDir = $publicDir;
+    }
+
+    /**
+     * Allow us to have multiple data roots for svg images.
+     *
+     * @param mixed $path
+     * @param mixed $filter
+     * @param mixed|null $resolver
+     * @param mixed $referenceType
+     */
+    public function filter(
+        $path,
+        $filter,
+        array $config = [],
+        $resolver = null,
+        $referenceType = UrlGeneratorInterface::ABSOLUTE_URL
+    ) {
+        $dataRoots = $this->loaders['default']['filesystem']['data_root'] ?? ['/media/image/'];
+
+        foreach (array_unique($dataRoots) as $imagePath) {
+            if (!$this->canImageBeFiltered($path) && file_exists(sprintf('%s/%s', $imagePath, $path))) {
+                return str_replace($this->publicDir, '', sprintf('%s/%s', $imagePath, $path));
+            }
+        }
+
+        /** @psalm-suppress DeprecatedClass */
+        return parent::filter($path, $filter, $config, $resolver, $referenceType);
+    }
+
+    private function canImageBeFiltered(string $path): bool
+    {
+        return !str_ends_with($path, '.svg');
+    }
+}


### PR DESCRIPTION
Issue: 
The `apps/sylius/vendor/sylius/sylius/src/Sylius/Bundle/CoreBundle/DependencyInjection/Compiler/LiipImageFiltersPass.php` forces the directory of an svg to be `'/media/image/'` but in the plugin we are allowing other `data_root`. This makes the svg to not be rendered when using a `liip_imagine` filter because the path is wrong.
In our case '/media/' so we can have an svg in `/media/gallery/images/`.
We loop through the existing `data_roots` and if it's an svg and the file exists we resolve the path.  

### Features

- Displays the svg in admin and front correctly because we resolve the right path
- Add width and height for svg in preview file to see it

https://github.com/monsieurbiz/SyliusMediaManagerPlugin/assets/111362284/8a8c2243-651b-40b7-af47-90fc8d09c116

Fix preview of svg in modal:
![Capture d’écran 2023-10-26 à 15 07 15](https://github.com/monsieurbiz/SyliusMediaManagerPlugin/assets/111362284/3487f123-eb6e-411f-aae4-451cfde4b4b2)
