### PR TITLE
Allow to require plugin in Sylius 2.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.2",
-        "sylius/sylius": "~2.0.0",
+        "sylius/sylius": "~2.0",
         "phpdocumentor/reflection-docblock": "^5.6"
     },
     "require-dev": {


### PR DESCRIPTION
Update composer.json with sylius version to not strictly be 2.0.X