### PR TITLE
Fixes and allow Sylius 2.1

### DIFF
--- a/.github/workflows/recipe.yaml
+++ b/.github/workflows/recipe.yaml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         php: [ '8.2', '8.3' ]
-        sylius: [ '~2.0.0' ]
+        sylius: [ '~2.0.0', '~2.0.1' ]
 
     steps:
       - name: Setup PHP

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .DEFAULT_GOAL := help
 SHELL=/bin/bash
 APP_DIR=tests/Application
-SYLIUS_VERSION=2.0.0
+SYLIUS_VERSION=2.1.0
 SYMFONY=cd ${APP_DIR} && symfony
 COMPOSER=symfony composer
 CONSOLE=${SYMFONY} console

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ setup_application:
 	(cd ${APP_DIR} && ${COMPOSER} config --no-plugins --json extra.symfony.endpoint '["https://api.github.com/repos/monsieurbiz/symfony-recipes/contents/index.json?ref=flex/master","flex://defaults"]')
 	(cd ${APP_DIR} && ${COMPOSER} require --no-install --no-scripts --no-progress sylius/sylius="~${SYLIUS_VERSION}") # Make sure to install the required version of sylius because the sylius-standard has a soft constraint
 	# Temporary fix for Sylius 2.1
-	(cd ${APP_DIR} && ${COMPOSER} require --no-install --no-scripts --no-progress api-platform/state)# Temporary fix for Sylius 2.1
+	(cd ${APP_DIR} && ${COMPOSER} require --no-install --no-scripts --no-progress api-platform/state)
 	# End Temporary fix for Sylius 2.1
 	$(MAKE) ${APP_DIR}/.php-version
 	$(MAKE) ${APP_DIR}/php.ini

--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,9 @@ setup_application:
 	(cd ${APP_DIR} && ${COMPOSER} config --no-plugins allow-plugins true)
 	(cd ${APP_DIR} && ${COMPOSER} config --no-plugins --json extra.symfony.endpoint '["https://api.github.com/repos/monsieurbiz/symfony-recipes/contents/index.json?ref=flex/master","flex://defaults"]')
 	(cd ${APP_DIR} && ${COMPOSER} require --no-install --no-scripts --no-progress sylius/sylius="~${SYLIUS_VERSION}") # Make sure to install the required version of sylius because the sylius-standard has a soft constraint
+	# Temporary fix for Sylius 2.1
+	(cd ${APP_DIR} && ${COMPOSER} require --no-install --no-scripts --no-progress api-platform/state)# Temporary fix for Sylius 2.1
+	# End Temporary fix for Sylius 2.1
 	$(MAKE) ${APP_DIR}/.php-version
 	$(MAKE) ${APP_DIR}/php.ini
 	(cd ${APP_DIR} && ${COMPOSER} install --no-interaction)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This plugin adds a media manager to your images, videos and other files type fie
 
 | Sylius Version | PHP Version |
 |----------------|-------------|
-| 2.0            | 8.2 - 8.3   |
+| 2.0, 2,1       | 8.2 - 8.3   |
 
 ℹ️ For Sylius 1.x, see our [1.x branch](https://github.com/monsieurbiz/SyliusMediaManagerPlugin/tree/1.x) and all 1.x releases.
 

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.2",
-        "sylius/sylius": "~2.0.0",
+        "sylius/sylius": "~2.0",
         "phpdocumentor/reflection-docblock": "^5.6"
     },
     "require-dev": {

--- a/dist/migrations/Version20250410102216.php
+++ b/dist/migrations/Version20250410102216.php
@@ -11,7 +11,7 @@
 
 declare(strict_types=1);
 
-namespace App;
+namespace DoctrineMigrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;

--- a/dist/src/Context/Channel/RequestBased/HostnameAndPortBasedRequestResolver.php
+++ b/dist/src/Context/Channel/RequestBased/HostnameAndPortBasedRequestResolver.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of Monsieur Biz' Media Manager plugin for Sylius.
+ *
+ * (c) Monsieur Biz <sylius@monsieurbiz.com>
+ *
+ * For the full copyright and license information, please view the LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace App\Context\Channel\RequestBased;
+
+use Sylius\Component\Channel\Context\RequestBased\RequestResolverInterface;
+use Sylius\Component\Channel\Model\ChannelInterface;
+use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+use Symfony\Component\HttpFoundation\Request;
+
+#[AutoconfigureTag('sylius.context.channel.request_based.resolver')]
+final class HostnameAndPortBasedRequestResolver implements RequestResolverInterface
+{
+    public function __construct(private ChannelRepositoryInterface $channelRepository)
+    {
+    }
+
+    public function findChannel(Request $request): ?ChannelInterface
+    {
+        return $this->channelRepository->findOneEnabledByHostname($request->getHost() . ':' . $request->getPort());
+    }
+}

--- a/dist/src/Entity/Product/Product.php
+++ b/dist/src/Entity/Product/Product.php
@@ -16,11 +16,15 @@ namespace App\Entity\Product;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Core\Model\Product as BaseProduct;
 use Sylius\Component\Product\Model\ProductTranslationInterface;
+use Sylius\MolliePlugin\Entity\ProductInterface;
+use Sylius\MolliePlugin\Entity\ProductTrait;
 
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_product')]
-class Product extends BaseProduct
+class Product extends BaseProduct implements ProductInterface
 {
+    use ProductTrait;
+
     #[ORM\Column(name: 'image_path', type: 'string', nullable: true)]
     private ?string $imagePath;
 

--- a/src/Components/ConfirmationModal.php
+++ b/src/Components/ConfirmationModal.php
@@ -21,7 +21,7 @@ use Symfony\UX\LiveComponent\Attribute\LiveProp;
 use Symfony\UX\LiveComponent\ComponentToolsTrait;
 use Symfony\UX\LiveComponent\DefaultActionTrait;
 
-#[AsLiveComponent]
+#[AsLiveComponent(route: 'sylius_admin_live_component')]
 class ConfirmationModal
 {
     use ComponentToolsTrait;

--- a/src/Components/FormField.php
+++ b/src/Components/FormField.php
@@ -21,7 +21,7 @@ use Symfony\UX\LiveComponent\Attribute\LiveProp;
 use Symfony\UX\LiveComponent\ComponentToolsTrait;
 use Symfony\UX\LiveComponent\DefaultActionTrait;
 
-#[AsLiveComponent]
+#[AsLiveComponent(route: 'sylius_admin_live_component')]
 class FormField
 {
     use ComponentToolsTrait;

--- a/src/Components/SelectionModal.php
+++ b/src/Components/SelectionModal.php
@@ -26,7 +26,7 @@ use Symfony\UX\LiveComponent\Attribute\LiveProp;
 use Symfony\UX\LiveComponent\ComponentToolsTrait;
 use Symfony\UX\LiveComponent\DefaultActionTrait;
 
-#[AsLiveComponent]
+#[AsLiveComponent(route: 'sylius_admin_live_component')]
 class SelectionModal
 {
     use ComponentToolsTrait;

--- a/src/Components/SelectionModal/DirectoryManager.php
+++ b/src/Components/SelectionModal/DirectoryManager.php
@@ -21,7 +21,7 @@ use Symfony\UX\LiveComponent\Attribute\LiveAction;
 use Symfony\UX\LiveComponent\Attribute\LiveProp;
 use Symfony\UX\LiveComponent\ComponentToolsTrait;
 
-#[AsLiveComponent]
+#[AsLiveComponent(route: 'sylius_admin_live_component')]
 class DirectoryManager
 {
     use ComponentToolsTrait;

--- a/src/Components/SelectionModal/FileListManager.php
+++ b/src/Components/SelectionModal/FileListManager.php
@@ -28,7 +28,7 @@ use Symfony\UX\LiveComponent\Attribute\LiveArg;
 use Symfony\UX\LiveComponent\Attribute\LiveProp;
 use Symfony\UX\LiveComponent\ComponentToolsTrait;
 
-#[AsLiveComponent]
+#[AsLiveComponent(route: 'sylius_admin_live_component')]
 final class FileListManager
 {
     use ComponentToolsTrait;

--- a/src/Components/SelectionModal/UploadManager.php
+++ b/src/Components/SelectionModal/UploadManager.php
@@ -26,7 +26,7 @@ use Symfony\UX\LiveComponent\Attribute\LiveAction;
 use Symfony\UX\LiveComponent\Attribute\LiveProp;
 use Symfony\UX\LiveComponent\ComponentToolsTrait;
 
-#[AsLiveComponent]
+#[AsLiveComponent(route: 'sylius_admin_live_component')]
 final class UploadManager
 {
     use ComponentToolsTrait;


### PR DESCRIPTION
- **fix(migration): rename dist file for doctrine migration**
- **feat(deps): Allow Sylius 2.1 and more**
- **fix(dist): Add channel context with port to avoid 404 channel not found**
- **fix(dist): fix dist file since Sylius standard integrates Mollie**
- **feat(live component): use Sylius route for admin live components**
