### PR TITLE
fix: display error messages if we add constraint on field

### DIFF
--- a/templates/form/_theme.html.twig
+++ b/templates/form/_theme.html.twig
@@ -9,6 +9,7 @@
         :maxFileSize="maxFileSize"
         :extraParams="extraParams"
     />
+    {{ form_errors(form) }}
     {{ form_help(form) }}
 {% endblock %}
 


### PR DESCRIPTION
<img width="435" height="142" alt="image" src="https://github.com/user-attachments/assets/e65c6efe-baee-4bab-8d9a-96518c0c0c13" />
